### PR TITLE
CAIP-25: Scope Extensions (with two examples)

### DIFF
--- a/CAIPs/caip-25.md
+++ b/CAIPs/caip-25.md
@@ -75,46 +75,40 @@ If a connection is rejected, the wallet MAY respond with a generic error or sile
           "wallet_authenticate",
           "wallet_pay"
         ],
-        "notifications": ["wallet_sessionChanged"]
-      },
-      "wallet:eip155": {
-        "methods": [
-          "personal_sign",
-          "wallet_grantPermissions",
-          "wallet_getAssets"
-        ],
-        "notifications": []
+        "notifications": ["wallet_sessionChanged"],
+        "exceptions": {
+          "wallet:eip155": {
+            "methods": [
+              "personal_sign",
+              "wallet_grantPermissions",
+              "wallet_getAssets"
+            ]
+          }
+        }
       },
       "eip155": {
+        "chains": ["1", "8453", "42161"],
         "methods": ["eth_sendTransaction"],
-        "notifications": ["accountsChanged", "chainChanged"]
-      },
-      "eip155:1": {
-        "methods": [],
-        "notifications": []
-      },
-      "eip155:8453": {
-        "methods": ["wallet_sendCalls"],
-        "notifications": []
-      },
-      "eip155:42161": {
-        "methods": ["wallet_sendCalls"],
-        "notifications": []
+        "notifications": ["accountsChanged", "chainChanged"],
+        "exceptions": {
+          "eip155:8453": {
+            "methods": ["wallet_sendCalls"]
+          },
+          "eip155:42161": {
+            "methods": ["wallet_sendCalls"]
+          }
+        }
       },
       "solana": {
+        "chains": [
+          "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+          "4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z"
+        ],
         "methods": [
           "solana_signMessage",
           "solana_signTransaction",
           "solana_signAndSendTransaction"
         ],
-        "notifications": []
-      },
-      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
-        "methods": [],
-        "notifications": []
-      },
-      "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z": {
-        "methods": [],
         "notifications": []
       }
     },
@@ -141,56 +135,62 @@ The `properties` object MAY be included for global session metadata.
     "sessionId": "0xdeadbeef",
     "scopes": {
       "wallet": {
-        "accounts": [],
-        "methods": ["wallet_authenticate", "wallet_pay"],
-        "notifications": [],
-        "capabilities": {}
-      },
-      "wallet:eip155": {
-        "accounts": [],
-        "methods": ["wallet_grantPermissions", "wallet_getAssets"],
-        "notifications": [],
-        "capabilities": {
-          "walletService": "https://wallet-service.example.com/rpc"
-        }
-      },
-      "eip155": {
-        "accounts": ["0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"],
-        "methods": ["eth_sendTransaction", "personal_sign"],
-        "notifications": ["accountsChanged", "chainChanged"],
-        "capabilities": {}
-      },
-      "eip155:1": {
-        "accounts": [],
-        "methods": [],
-        "notifications": [],
-        "capabilities": {}
-      },
-      "eip155:8453": {
-        "accounts": [],
-        "methods": ["wallet_sendCalls"],
-        "notifications": [],
-        "capabilities": {
-          "atomic": {
-            "status": "supported"
+        "methods": [
+          "wallet_revokeSession",
+          "wallet_getSession",
+          "wallet_authenticate",
+          "wallet_pay"
+        ],
+        "notifications": ["wallet_sessionChanged"],
+        "capabilities": {},
+        "exceptions": {
+          "wallet:eip155": {
+            "methods": [
+              "personal_sign",
+              "wallet_grantPermissions",
+              "wallet_getAssets"
+            ],
+            "capabilities": {
+              "walletService": "https://wallet-service.example.com/rpc"
+            }
           }
         }
       },
-      "eip155:42161": {
-        "accounts": ["0x0495766cD136138Fc492Dd499B8DC87A92D6685b"],
-        "methods": ["wallet_sendCalls"],
-        "notifications": [],
-        "capabilities": {
-          "atomic": {
-            "status": "supported"
+      "eip155": {
+        "chains": ["1", "8453", "42161"],
+        "accounts": ["0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"],
+        "methods": ["eth_sendTransaction", "personal_sign"],
+        "notifications": ["accountsChanged", "chainChanged"],
+        "capabilities": {},
+        "exceptions": {
+          "eip155:8453": {
+            "methods": ["wallet_sendCalls"],
+            "capabilities": {
+              "atomic": {
+                "status": "supported"
+              }
+            }
           },
-          "paymasterService": {
-            "url": "https://...",
-            "optional": true
+          "eip155:42161": {
+            "accounts": ["0x0495766cD136138Fc492Dd499B8DC87A92D6685b"],
+            "methods": ["wallet_sendCalls"],
+            "capabilities": {
+              "atomic": {
+                "status": "supported"
+              },
+              "paymasterService": {
+                "url": "https://...",
+                "optional": true
+              }
+            }
           }
         }
       },
       "solana": {
+        "chains": [
+          "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+          "4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z"
+        ],
         "accounts": [],
         "methods": [
           "solana_signMessage",
@@ -200,21 +200,18 @@ The `properties` object MAY be included for global session metadata.
         "notifications": [],
         "capabilities": {
           "supportedTransactionVersions": ["legacy"]
+        },
+        "exceptions": {
+          "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
+            "accounts": ["7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBMHyRWXArAaKv"],
+            "capabilities": {
+              "supportedTransactionVersions": ["0"]
+            }
+          },
+          "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z": {
+            "accounts": ["6LmSRCiu3z6NCSpF19oz1pHXkYkN4jWbj9K1nVELpDkT"]
+          }
         }
-      },
-      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
-        "accounts": ["7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBMHyRWXArAaKv"],
-        "methods": [],
-        "notifications": [],
-        "capabilities": {
-          "supportedTransactionVersions": ["0"]
-        }
-      },
-      "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z": {
-        "accounts": ["6LmSRCiu3z6NCSpF19oz1pHXkYkN4jWbj9K1nVELpDkT"],
-        "methods": [],
-        "notifications": [],
-        "capabilities": {}
       }
     },
     "properties": {

--- a/CAIPs/caip-25.md
+++ b/CAIPs/caip-25.md
@@ -76,7 +76,7 @@ If a connection is rejected, the wallet MAY respond with a generic error or sile
           "wallet_pay"
         ],
         "notifications": ["wallet_sessionChanged"],
-        "exceptions": {
+        "extensions": {
           "wallet:eip155": {
             "methods": [
               "personal_sign",
@@ -90,7 +90,7 @@ If a connection is rejected, the wallet MAY respond with a generic error or sile
         "chains": ["1", "8453", "42161"],
         "methods": ["eth_sendTransaction"],
         "notifications": ["accountsChanged", "chainChanged"],
-        "exceptions": {
+        "extensions": {
           "eip155:8453": {
             "methods": ["wallet_sendCalls"]
           },
@@ -143,7 +143,7 @@ The `properties` object MAY be included for global session metadata.
         ],
         "notifications": ["wallet_sessionChanged"],
         "capabilities": {},
-        "exceptions": {
+        "extensions": {
           "wallet:eip155": {
             "methods": [
               "personal_sign",
@@ -162,7 +162,7 @@ The `properties` object MAY be included for global session metadata.
         "methods": ["eth_sendTransaction", "personal_sign"],
         "notifications": ["accountsChanged", "chainChanged"],
         "capabilities": {},
-        "exceptions": {
+        "extensions": {
           "eip155:8453": {
             "methods": ["wallet_sendCalls"],
             "capabilities": {
@@ -201,7 +201,7 @@ The `properties` object MAY be included for global session metadata.
         "capabilities": {
           "supportedTransactionVersions": ["legacy"]
         },
-        "exceptions": {
+        "extensions": {
           "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
             "accounts": ["7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBMHyRWXArAaKv"],
             "capabilities": {

--- a/CAIPs/caip-25.md
+++ b/CAIPs/caip-25.md
@@ -61,7 +61,42 @@ If a connection is rejected, the wallet MAY respond with a generic error or sile
 
 #### Request
 
+TODO
+
+The `scopes` object MUST contain one or more scopeObjects.
+
+The `properties` object MAY be included for global session metadata.
+
+### Response
+
+#### Success
+
+TODO
+
+Each entry within `scopes` object MAY contain `accounts` and `capabilities` as part of its object for success response.
+
+#### Error Codes
+
+The wallet MAY return generic or specific error messages depending on trust. Trusted responses may include codes like:
+
+- `5000`: Unknown error
+- `5001`: User disapproved requested methods
+- `5002`: User disapproved requested notifications
+- `5100-5102`: Unsupported chains, methods, or notifications
+- `5201-5302`: Malformed requests
+
+## Examples
+
+Example 1 - BLA BLA BLA
+
+<table>
+
+<tr>
+
+<td>
+
 ```jsonc
+// JSON-RPC REQUEST
 {
   "id": 1,
   "jsonrpc": "2.0",
@@ -119,15 +154,12 @@ If a connection is rejected, the wallet MAY respond with a generic error or sile
 }
 ```
 
-The `scopes` object MUST contain one or more scopeObjects.
+</td>
 
-The `properties` object MAY be included for global session metadata.
-
-### Response
-
-#### Success
+<td>
 
 ```jsonc
+// JSON-RPC RESPONSE
 {
   "id": 1,
   "jsonrpc": "2.0",
@@ -227,17 +259,11 @@ The `properties` object MAY be included for global session metadata.
 }
 ```
 
-Each entry within `scopes` object MAY contain `accounts` and `capabilities` as part of its object for success response.
+</td>
 
-#### Error Codes
+</tr>
 
-The wallet MAY return generic or specific error messages depending on trust. Trusted responses may include codes like:
-
-- `5000`: Unknown error
-- `5001`: User disapproved requested methods
-- `5002`: User disapproved requested notifications
-- `5100-5102`: Unsupported chains, methods, or notifications
-- `5201-5302`: Malformed requests
+</table>
 
 ## Security Considerations
 

--- a/CAIPs/caip-25.md
+++ b/CAIPs/caip-25.md
@@ -89,9 +89,9 @@ The wallet MAY return generic or specific error messages depending on trust. Tru
 
 Example 1 - BLA BLA BLA
 
-<table>
+<table style="border-collapse: collapse; border: 0; width: 100%; table-layout: fixed;">
 
-<tr>
+<tr style="vertical-align: top; width: 50%; padding: 0; border: 0;">
 
 <td>
 

--- a/CAIPs/caip-25.md
+++ b/CAIPs/caip-25.md
@@ -49,7 +49,7 @@ Callers may revoke sessions using `wallet_revokeSession`, passing the `sessionId
 
 Authorization requests are expressed as a top-level object `scopes` containing keyed [scopeObjects][CAIP-217].
 
-Each `scopeObject` is keyed by a [CAIP-2][] chain ID. A null reference can be used to refer to a scope that applies to ANY chain within that namespace (eg. `eip155:0`)
+Each `scopeObject` is keyed by a [CAIP-2][] or [CAIP-104][] identifiers. A null reference can be used to refer to a scope that applies to ANY chain within that namespace (eg. `eip155:0`)
 
 Wallets MAY authorize a subset of scopes or scope properties as requested, and MAY also authorize additional scopes or scope properties. This enables granular control and flexibility on the part of the respondent.
 
@@ -154,15 +154,6 @@ For request, we define a very simple scope for 10 EVM chains with the exact same
   "method": "wallet_createSession",
   "params": {
     "scopes": {
-      "wallet": {
-        "methods": ["wallet_revokeSession", "wallet_getSession"],
-        "notifications": ["wallet_sessionChanged"],
-        "extensions": {
-          "wallet:eip155": {
-            "methods": ["personal_sign"]
-          }
-        }
-      },
       "eip155": {
         "chains": [
           "1",
@@ -176,7 +167,7 @@ For request, we define a very simple scope for 10 EVM chains with the exact same
           "534352",
           "747474"
         ],
-        "methods": ["eth_sendTransaction"],
+        "methods": ["eth_sendTransaction", "personal_sign"],
         "notifications": ["accountsChanged", "chainChanged"]
       }
     },
@@ -196,16 +187,6 @@ For response, we also keep it quite simple with no scope extensions or wallet ca
   "jsonrpc": "2.0",
   "result": {
     "scopes": {
-      "wallet": {
-        "accounts": [],
-        "methods": ["wallet_revokeSession", "wallet_getSession"],
-        "notifications": ["wallet_sessionChanged"],
-        "extensions": {
-          "wallet:eip155": {
-            "methods": ["personal_sign"]
-          }
-        }
-      },
       "eip155": {
         "chains": [
           "1",
@@ -220,7 +201,7 @@ For response, we also keep it quite simple with no scope extensions or wallet ca
           "747474"
         ],
         "accounts": ["0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"],
-        "methods": ["eth_sendTransaction"],
+        "methods": ["eth_sendTransaction", "personal_sign"],
         "notifications": ["accountsChanged", "chainChanged"]
       }
     },
@@ -233,7 +214,7 @@ For response, we also keep it quite simple with no scope extensions or wallet ca
 
 **Example 2**
 
-For the request, we define the expectation of 3 EVM chains with similar scope but with 2 of them that have extensions for capabilities. Additonally we have 2 Solana chains with similar scope
+For the request, we define the expectation of 5 EVM chains with similar scope and additonally we have 2 Solana chains with similar scope
 
 ```jsonc
 // JSON-RPC REQUEST
@@ -243,28 +224,15 @@ For the request, we define the expectation of 3 EVM chains with similar scope bu
   "method": "wallet_createSession",
   "params": {
     "scopes": {
-      "wallet": {
-        "methods": [
-          "wallet_revokeSession",
-          "wallet_getSession",
-          "wallet_authenticate",
-          "wallet_pay"
-        ],
-        "notifications": ["wallet_sessionChanged"],
-        "extensions": {
-          "wallet:eip155": {
-            "methods": [
-              "personal_sign",
-              "wallet_grantPermissions",
-              "wallet_getAssets",
-              "wallet_sendCalls"
-            ]
-          }
-        }
-      },
       "eip155": {
-        "chains": ["1", "8453", "42161"],
-        "methods": ["eth_sendTransaction"],
+        "chains": ["1", "10", "324", "8453", "42161"],
+        "methods": [
+          "eth_sendTransaction",
+          "personal_sign",
+          "wallet_grantPermissions",
+          "wallet_getAssets",
+          "wallet_sendCalls"
+        ],
         "notifications": ["accountsChanged", "chainChanged"]
       },
       "solana": {
@@ -287,11 +255,11 @@ For the request, we define the expectation of 3 EVM chains with similar scope bu
 }
 ```
 
-For the response, we match the same scopes as the request but include an EVM-wide capability under `wallet:eip155` plus we describe a EVM capability only available for a single chain which also has a chain-specific account available.
+For the response, we match the same scopes as the request but segregate 2 out of 5 EVM chains into their scopes because of either exclusive accounts or capabilities.
 
 Additionaly we have the two Solana chains returning the same scopes but returning two different account addresses for each chain including a unique capability for one of the chains
 
-Finally the wallet has provided with the additional walletInfo session property.
+Finally the wallet has provided within properties with its walletInfo per [CAIP-372][].
 
 ```jsonc
 // JSON-RPC RESPONSE
@@ -301,36 +269,20 @@ Finally the wallet has provided with the additional walletInfo session property.
   "result": {
     "sessionId": "0xdeadbeef",
     "scopes": {
-      "wallet": {
-        "accounts": [],
-        "methods": [
-          "wallet_revokeSession",
-          "wallet_getSession",
-          "wallet_authenticate",
-          "wallet_pay"
-        ],
-        "notifications": ["wallet_sessionChanged"],
-        "capabilities": {},
-        "extensions": {
-          "wallet:eip155": {
-            "methods": [
-              "personal_sign",
-              "wallet_grantPermissions",
-              "wallet_getAssets",
-              "wallet_sendCalls"
-            ],
-            "capabilities": {
-              "walletService": "https://wallet-service.example.com/rpc"
-            }
-          }
-        }
-      },
       "eip155": {
-        "chains": ["1", "8453", "42161"],
+        "chains": ["1", "10", "324", "8453", "42161"],
         "accounts": ["0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"],
-        "methods": ["eth_sendTransaction"],
+        "methods": [
+          "eth_sendTransaction",
+          "personal_sign",
+          "wallet_grantPermissions",
+          "wallet_getAssets",
+          "wallet_sendCalls"
+        ],
         "notifications": ["accountsChanged", "chainChanged"],
-        "capabilities": {},
+        "capabilities": {
+          "walletService": "https://wallet-service.example.com/rpc"
+        },
         "extensions": {
           "eip155:8453": {
             "capabilities": {
@@ -426,6 +378,7 @@ To mitigate fingerprinting risks, wallets should prefer uniform or silent failur
 - [CAIP-312][] - `wallet_getSession` Specification
 - [CAIP-311][] - `wallet_sessionChanged` Specification
 - [CAIP-316][] - Session Lifecycle Management equivalence chart and diagrams
+- [CAIP-372][] - Wallet Information Metadata Standard
 - [RFC-2119][] - Key words for use in RFCs to Indicate Requirement Levels
 
 [CAIP-2]: https://chainagnostic.org/CAIPs/caip-2
@@ -437,6 +390,7 @@ To mitigate fingerprinting risks, wallets should prefer uniform or silent failur
 [CAIP-312]: https://chainagnostic.org/CAIPs/CAIP-312
 [CAIP-311]: https://chainagnostic.org/CAIPs/CAIP-311
 [CAIP-316]: https://chainagnostic.org/CAIPs/caip-316
+[CAIP-372]: https://chainagnostic.org/CAIPs/caip-372
 [RFC-2119]: https://datatracker.ietf.org/doc/html/rfc2119
 
 ## Copyright

--- a/CAIPs/caip-25.md
+++ b/CAIPs/caip-25.md
@@ -159,7 +159,7 @@ The `properties` object MAY be included for global session metadata.
       "eip155": {
         "chains": ["1", "8453", "42161"],
         "accounts": ["0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"],
-        "methods": ["eth_sendTransaction", "personal_sign"],
+        "methods": ["eth_sendTransaction"],
         "notifications": ["accountsChanged", "chainChanged"],
         "capabilities": {},
         "extensions": {

--- a/CAIPs/caip-25.md
+++ b/CAIPs/caip-25.md
@@ -402,12 +402,6 @@ Finally the wallet has provided with the additional walletInfo session property.
 }
 ```
 
-</td>
-
-</tr>
-
-</table>
-
 ## Security Considerations
 
 To avoid ambiguity in authorizations, `scopes` MUST retain their original keyed structure using [CAIP-2][] or [CAIP-104][] identifiers. This ensures clarity in what is authorized and prevents accidental scope merging or misinterpretation.

--- a/CAIPs/caip-25.md
+++ b/CAIPs/caip-25.md
@@ -81,7 +81,8 @@ If a connection is rejected, the wallet MAY respond with a generic error or sile
             "methods": [
               "personal_sign",
               "wallet_grantPermissions",
-              "wallet_getAssets"
+              "wallet_getAssets",
+              "wallet_sendCalls"
             ]
           }
         }
@@ -89,15 +90,7 @@ If a connection is rejected, the wallet MAY respond with a generic error or sile
       "eip155": {
         "chains": ["1", "8453", "42161"],
         "methods": ["eth_sendTransaction"],
-        "notifications": ["accountsChanged", "chainChanged"],
-        "extensions": {
-          "eip155:8453": {
-            "methods": ["wallet_sendCalls"]
-          },
-          "eip155:42161": {
-            "methods": ["wallet_sendCalls"]
-          }
-        }
+        "notifications": ["accountsChanged", "chainChanged"]
       },
       "solana": {
         "chains": [
@@ -148,7 +141,8 @@ The `properties` object MAY be included for global session metadata.
             "methods": [
               "personal_sign",
               "wallet_grantPermissions",
-              "wallet_getAssets"
+              "wallet_getAssets",
+              "wallet_sendCalls"
             ],
             "capabilities": {
               "walletService": "https://wallet-service.example.com/rpc"
@@ -164,7 +158,6 @@ The `properties` object MAY be included for global session metadata.
         "capabilities": {},
         "extensions": {
           "eip155:8453": {
-            "methods": ["wallet_sendCalls"],
             "capabilities": {
               "atomic": {
                 "status": "supported"
@@ -173,7 +166,6 @@ The `properties` object MAY be included for global session metadata.
           },
           "eip155:42161": {
             "accounts": ["0x0495766cD136138Fc492Dd499B8DC87A92D6685b"],
-            "methods": ["wallet_sendCalls"],
             "capabilities": {
               "atomic": {
                 "status": "supported"

--- a/CAIPs/caip-25.md
+++ b/CAIPs/caip-25.md
@@ -61,7 +61,31 @@ If a connection is rejected, the wallet MAY respond with a generic error or sile
 
 #### Request
 
-TODO
+```typescript
+interface CAIP25JsonRpcRequest {
+  id: number;
+  jsonrpc: "2.0";
+  method: "wallet_createSession";
+  params: {
+    scopes: {
+      [scopeKey: string]: {
+        chains?: string[];
+        methods: string[];
+        notifications: string[];
+        extensions?: {
+          [chainId: string]: {
+            methods?: string[];
+            notifications?: string[];
+          };
+        };
+      };
+    };
+    properties?: {
+      [propertyKey: string]: any;
+    };
+  };
+}
+```
 
 The `scopes` object MUST contain one or more scopeObjects.
 
@@ -71,7 +95,38 @@ The `properties` object MAY be included for global session metadata.
 
 #### Success
 
-TODO
+```typescript
+interface CAIP25JsonRpcRequest {
+  id: number;
+  jsonrpc: "2.0";
+  result: {
+    scopes: {
+      [scopeKey: string]: {
+        chains?: string[];
+        accounts: string[];
+        methods: string[];
+        notifications: string[];
+        capabilities?: {
+          [capabilityKey: string]: any;
+        };
+        extensions?: {
+          [chainId: string]: {
+            accounts?: string[];
+            methods?: string[];
+            notifications?: string[];
+            capabilities?: {
+              [capabilityKey: string]: any;
+            };
+          };
+        };
+      };
+    };
+    properties?: {
+      [propertyKey: string]: any;
+    };
+  };
+}
+```
 
 Each entry within `scopes` object MAY contain `accounts` and `capabilities` as part of its object for success response.
 
@@ -87,13 +142,98 @@ The wallet MAY return generic or specific error messages depending on trust. Tru
 
 ## Examples
 
-Example 1 - BLA BLA BLA
+**Example 1**
 
-<table style="border-collapse: collapse; border: 0; width: 100%; table-layout: fixed;">
+For request, we define a very simple scope for 10 EVM chains with the exact same scope and no extensions.
 
-<tr style="vertical-align: top; width: 50%; padding: 0; border: 0;">
+```jsonc
+// JSON-RPC REQUEST
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "wallet_createSession",
+  "params": {
+    "scopes": {
+      "wallet": {
+        "methods": ["wallet_revokeSession", "wallet_getSession"],
+        "notifications": ["wallet_sessionChanged"],
+        "extensions": {
+          "wallet:eip155": {
+            "methods": ["personal_sign"]
+          }
+        }
+      },
+      "eip155": {
+        "chains": [
+          "1",
+          "10",
+          "130",
+          "324",
+          "2741",
+          "8453",
+          "42161",
+          "59144",
+          "534352",
+          "747474"
+        ],
+        "methods": ["eth_sendTransaction"],
+        "notifications": ["accountsChanged", "chainChanged"]
+      }
+    },
+    "properties": {
+      "expiry": "2022-12-24T17:07:31+00:00"
+    }
+  }
+}
+```
 
-<td>
+For response, we also keep it quite simple with no scope extensions or wallet capabilities and responded back with just a single account matching all requested EVM chains.
+
+```jsonc
+// JSON-RPC RESPONSE
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": {
+    "scopes": {
+      "wallet": {
+        "accounts": [],
+        "methods": ["wallet_revokeSession", "wallet_getSession"],
+        "notifications": ["wallet_sessionChanged"],
+        "extensions": {
+          "wallet:eip155": {
+            "methods": ["personal_sign"]
+          }
+        }
+      },
+      "eip155": {
+        "chains": [
+          "1",
+          "10",
+          "130",
+          "324",
+          "2741",
+          "8453",
+          "42161",
+          "59144",
+          "534352",
+          "747474"
+        ],
+        "accounts": ["0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"],
+        "methods": ["eth_sendTransaction"],
+        "notifications": ["accountsChanged", "chainChanged"]
+      }
+    },
+    "properties": {
+      "expiry": "2022-12-24T17:07:31+00:00"
+    }
+  }
+}
+```
+
+**Example 2**
+
+For the request, we define the expectation of 3 EVM chains with similar scope but with 2 of them that have extensions for capabilities. Additonally we have 2 Solana chains with similar scope
 
 ```jsonc
 // JSON-RPC REQUEST
@@ -154,9 +294,11 @@ Example 1 - BLA BLA BLA
 }
 ```
 
-</td>
+For the response, we match the same scopes as the request but include an EVM-wide capability under `wallet:eip155` plus we describe a EVM capability only available for a single chain which also has a chain-specific account available.
 
-<td>
+Additionaly we have the two Solana chains returning the same scopes but returning two different account addresses for each chain including a unique capability for one of the chains
+
+Finally the wallet has provided with the additional walletInfo session property.
 
 ```jsonc
 // JSON-RPC RESPONSE
@@ -167,6 +309,7 @@ Example 1 - BLA BLA BLA
     "sessionId": "0xdeadbeef",
     "scopes": {
       "wallet": {
+        "accounts": [],
         "methods": [
           "wallet_revokeSession",
           "wallet_getSession",


### PR DESCRIPTION
Introducing `extensions` to reduce verbosity

PLUS renaming `references` to `chains`